### PR TITLE
Fix setup readlink resolution

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,34 @@
 # Customize this file by setting variables to suit your environment
 SOURCE="${BASH_SOURCE[0]}"
 SOURCE_DIR=`dirname $SOURCE`
-export QUICKFAST_ROOT=`readlink -f $SOURCE_DIR`
+$READLINK --version >/dev/null 2>/dev/null
+if (( $? != 0 )); then
+    echo "readlink does not exist or it does not support --version"
+    echo "maybe it is not GNU readlink but BSD"
+    echo "trying with greadlink..."
+    READLINK='greadlink'
+fi
+$READLINK --version >/dev/null 2>/dev/null
+if (( $? != 0 )); then
+    echo "greadlink does not exist or an error occurred"
+    UNAME=`uname`
+    if [[ $UNAME == "Darwin" ]]; then
+        echo "You are running on a Mac OSX system."
+        echo "Consider installing homebrew."
+        echo "Then install coreutils."
+        echo "# brew install coreutils"
+    fi
+else
+    echo "$READLINK found at `which $READLINK`."
+fi
+$READLINK -f $SOURCE_DIR
+if (( $? != 0 )); then
+    echo "trying exporting QUICKFAST_ROOT by pwd."
+    export QUICKFAST_ROOT=`pwd`
+    echo "QUICKFAST_ROOT = $QUICKFAST_ROOT"
+else
+    export QUICKFAST_ROOT=`$READLINK -f $SOURCE_DIR`
+fi
 
 if test "$MPC_ROOT" = ""
 then


### PR DESCRIPTION
Hello,

Just a note so i wont forget it.

I was playing with quickfast and liquibook on my osx box and i found a problem with readlink on BSD systems.

I added some code to setup.sh in order to resolve the correct readlink program.

On an osx box, we should install coreutils that provided greadlink.

It can be done through homebrew by issuing

`````
brew install coreutils
`````

Please verify if this solution can provide a more robust implementation of the setup shell script.

Thanks,

Edu.